### PR TITLE
Updated ivy.xml with snappy-java dependency

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -193,6 +193,8 @@ under the License.
       conf="avro->default;redist->default">
       <exclude org="com.twitter" module="parquet-hive-bundle"/>
     </dependency>
+    <dependency org="org.xerial.snappy" name="snappy-java" rev="1.1.1" 
+      conf="common->default;redist->default"/>
 
     <!-- dependencies for static analysis -->
     <dependency org="checkstyle" name="checkstyle" rev="${checkstyle.version}"


### PR DESCRIPTION
Added snappy-java 1.1.1 dependency in the ivy.xml file for ppc support. Resolves #1 
